### PR TITLE
BUG: Fixed print_data function to print Layer 1 and 2 weights. Fixed …

### DIFF
--- a/fancy_mlp.py
+++ b/fancy_mlp.py
@@ -6,11 +6,12 @@ def applySigmoid(x, giveMeTheDerivative = False):
 		return x * (1 - x)
 	return 1 / (1 + np.exp(-x))
 
-def print_data(iter, inputs, keys, weights, prediction):
+def print_data(iter, inputs, keys, layer_one_weights, layer_two_weights, prediction):
 	print "This is iteration # ", iter
 	print "Your original input data was... \n", inputs
 	print "Your orignal keys were... \n", keys
-	print "Your weights at this specific iteration are... \n", weights
+	print "Layer one weights at this specific iteration are... \n", layer_one_weights
+	print "Layer two weights at this specific iteration are... \n", layer_two_weights
 	print "Our prediction at this iteration was... \n", prediction
 	print "--------------------------------------------------\n"
 
@@ -36,17 +37,17 @@ def train(inputs, keys, layer_one_weights, layer_two_weights):
 		layer_one_error = np.dot(layer_two_change_in_error, layer_two_weights.T)
 
 		# Just like in simple_mlp.py
-		layer_one_change_in_error = layer_one_error * applySigmoid(layer_one_error, True)
+        	layer_one_change_in_error = layer_one_error * applySigmoid(layer_one_prediction, True)
 
 		# adjust your weights accoridngly.
-		layer_one_weights +=  np.dot(layer_one_prediction.T, layer_one_change_in_error)
-		layer_two_weights +=  np.dot(layer_two_prediction.T, layer_two_change_in_error)
+		layer_one_weights +=  np.dot(inputs.T, layer_one_change_in_error)
+		layer_two_weights +=  np.dot(layer_one_prediction.T, layer_two_change_in_error)
 
 		if(iter == 0 or iter == 5000 or iter == 9999):
-			print_data(iter, inputs, keys, weights, prediction)
+			print_data(iter, inputs, keys, layer_one_weights, layer_two_weights, layer_two_prediction)
 
 	print "Output After Training:"
-	print prediction
+	print layer_two_prediction
 
 def main():
 	np.random.seed(1)


### PR DESCRIPTION
…layer_two_change_in_error value in train by calling applySigmoid with layer_one_prediction instead of layer_one_error. Fixed layer 1 and 2 weights update namely using dot on inputs and layer_one_change_in_error and second dot on layer_one_prediction and layer_two_change_in_error instead of previous version. Fixed call to print_data with additional arguments. Fixed prediction print call using layer_two_prediction instead.